### PR TITLE
Pin amqp-dep to get rid of outdated lodash dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha tests"
   },
   "dependencies": {
-    "amqp": "*",
+    "amqp": "^0.2.7",
     "redis": "*",
     "uuid": "^3.0.0"
   },


### PR DESCRIPTION
we don't use amqp, but this way we don't have to touch the code and remove it.